### PR TITLE
Sentry http intrumentation

### DIFF
--- a/lib/src/requests/requests.dart
+++ b/lib/src/requests/requests.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart' as io_client;
+import 'package:sentry/sentry.dart';
 
 import 'common.dart';
 import 'event.dart';
@@ -334,7 +335,7 @@ class Requests {
       client = io_client.IOClient(ioClient);
     } else {
       // The default client validates SSL certificates and fail if invalid
-      client = http.Client();
+      client = SentryHttpClient(client: http.Client());
     }
 
     Uri uri = Uri.parse(url);

--- a/lib/src/requests/requests.dart
+++ b/lib/src/requests/requests.dart
@@ -334,7 +334,9 @@ class Requests {
       ioClient.badCertificateCallback = (_, __, ___) => true;
       client = io_client.IOClient(ioClient);
     } else {
-      // The default client validates SSL certificates and fail if invalid
+      // The default client:
+      // validates SSL certificates and fails if invalid
+      // logs all calls to Sentry
       client = SentryHttpClient(client: http.Client());
     }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -594,6 +594,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
+  package_info_plus_linux:
+    dependency: transitive
+    description:
+      name: package_info_plus_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
+  package_info_plus_macos:
+    dependency: transitive
+    description:
+      name: package_info_plus_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
+  package_info_plus_web:
+    dependency: transitive
+    description:
+      name: package_info_plus_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
+  package_info_plus_windows:
+    dependency: transitive
+    description:
+      name: package_info_plus_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
   path:
     dependency: "direct main"
     description:
@@ -728,9 +770,16 @@ packages:
     source: hosted
     version: "2.2.0-nullsafety"
   sentry:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: sentry
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.1.0"
+  sentry_flutter:
+    dependency: "direct main"
+    description:
+      name: sentry_flutter
       url: "https://pub.dartlang.org"
     source: hosted
     version: "5.1.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -727,6 +727,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.0-nullsafety"
+  sentry:
+    dependency: "direct main"
+    description:
+      name: sentry
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.1.0"
   share_extend:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   provider: ^5.0.0
   random_string: ^2.2.0-nullsafety
   shared_preferences: ^2.0.6
-  sentry: ^5.1.0
+  sentry_flutter: ^5.1.0
   simple_animations: ^3.1.1
   url_launcher: ^6.0.8
   video_player: ^2.1.10

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   provider: ^5.0.0
   random_string: ^2.2.0-nullsafety
   shared_preferences: ^2.0.6
+  sentry: ^5.1.0
   simple_animations: ^3.1.1
   url_launcher: ^6.0.8
   video_player: ^2.1.10


### PR DESCRIPTION
Adding Sentry as a dependecy.  Verified apps without Sentry configured still work using Requests.